### PR TITLE
Encrypt signed exits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-version v1.6.0
-	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2
-	github.com/nodeset-org/nodeset-client-go v1.1.0
+	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241007163607-e439ed3db62f
+	github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963
 	github.com/nodeset-org/osha v0.3.1
 	github.com/rocket-pool/batch-query v1.0.0
 	github.com/rocket-pool/node-manager-core v0.5.2-0.20241003024529-05c829d805c6
@@ -24,6 +24,7 @@ require (
 )
 
 require (
+	filippo.io/age v1.2.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240716105424-66b64c4bb379 // indirect
 	github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-version v1.6.0
-	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241008194042-73dbca474c7e
+	github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1
 	github.com/nodeset-org/nodeset-client-go v1.2.0
 	github.com/nodeset-org/osha v0.3.1
 	github.com/rocket-pool/batch-query v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,11 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-version v1.6.0
-	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241007163607-e439ed3db62f
-	github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963
+	github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241008194042-73dbca474c7e
+	github.com/nodeset-org/nodeset-client-go v1.2.0
 	github.com/nodeset-org/osha v0.3.1
 	github.com/rocket-pool/batch-query v1.0.0
-	github.com/rocket-pool/node-manager-core v0.5.2-0.20241003024529-05c829d805c6
+	github.com/rocket-pool/node-manager-core v0.5.2-0.20241008173134-e04f3c1b9051
 	github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b
 	github.com/rocket-pool/smartnode/v2 v2.0.0-olddev.0.20240710181452-edcbd6208bdd
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805 h1:u2qwJeEvnypw+OCPUHmoZE3IqwfuN5kgDfo5MLzpNM0=
+c2sp.org/CCTV/age v0.0.0-20240306222714-3ec4d716e805/go.mod h1:FomMrUJ2Lxt5jCLmZkG3FHa72zUprnhd3v/Z18Snm4w=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/jaeger v0.2.1 h1:yGBYzYMewVL0yO9qqJv3Z5+IRhPdU7e9o/2oKpX4YvI=
 contrib.go.opencensus.io/exporter/jaeger v0.2.1/go.mod h1:Y8IsLgdxqh1QxYxPC5IgXVmBaeLUeQFfBeBi9PbeZd0=
+filippo.io/age v1.2.0 h1:vRDp7pUMaAJzXNIWJVAZnEf/Dyi4Vu4wI8S1LBzufhE=
+filippo.io/age v1.2.0/go.mod h1:JL9ew2lTN+Pyft4RiNGguFfOpewKwSHm5ayKD/A4004=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240716105424-66b64c4bb379 h1:shYAfOpsleWVaSwGxQjmi+BBIwzj5jxB1FTCpVqs0N8=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240716105424-66b64c4bb379/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/AdamKorcz/go-118-fuzz-build v0.0.0-20231105174938-2b5cbb29f3e2 h1:dIScnXFlF784X79oi7MzVT6GWqr/W1uUt0pB5CsDs9M=
@@ -391,10 +395,10 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2 h1:xFYeiFwIhMQSS2ce/jeh4MDTPDM9L/Xb3NJDBw+NfEk=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2/go.mod h1:JiseFwKiyDFhrPvhpbMb/yLkSq3jhzGLM1Q3vg56CfQ=
-github.com/nodeset-org/nodeset-client-go v1.1.0 h1:VjpU8FmRm+K37BRuHpBSO+nl4VWsc2etCmtxVpvchtk=
-github.com/nodeset-org/nodeset-client-go v1.1.0/go.mod h1:slpwejkJ/vYU9SKA3SYw4hIPJLzDUeQxcx+Cm04kkIA=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241007163607-e439ed3db62f h1:ogjzXS/x5bbPL5IGiIO7SS+kEgCs79m8p/Xl5qjqxkY=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241007163607-e439ed3db62f/go.mod h1:NS0CuHVVWW++j933beSACsJXFBdcH5TKRzBXIJmnacQ=
+github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963 h1:DhjPEnbtzPUEG+/INKjNHs7Q5JYA2aUURttcOD4WvGI=
+github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
 github.com/nodeset-org/osha v0.3.1 h1:xHDjCswxGDazY/UsZ0QOpcu7gTVnEuUwXcKGVAz72lI=
 github.com/nodeset-org/osha v0.3.1/go.mod h1:47D6kYMuxYDTbul3w/YtE1LKA0hfzbXzCEC3M9oQlOU=
 github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20240731214747-81867bb8ff63 h1:8SYjAfLErqH0zRu4s+17oAmFE0MrAS3GcTaIIm3u1O0=

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241008194042-73dbca474c7e h1:5m+qFLazQKcx9+p0Wv5SaMZFt7ztZW5CkRRFgPTOyV8=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241008194042-73dbca474c7e/go.mod h1:Vjdz7D7gAZr0NFMLgBfQN1/9/Nh+KiCFJWj+7tFcFTQ=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1 h1:H7mfO7upKMvPmpl1wOLR8IU8EEcagnPdVl0BEV/TBLk=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1/go.mod h1:Vjdz7D7gAZr0NFMLgBfQN1/9/Nh+KiCFJWj+7tFcFTQ=
 github.com/nodeset-org/nodeset-client-go v1.2.0 h1:16GfFTkjMdgGiAdXWyLLMnLVHd+E6Rh+UYzS1i8/o+I=
 github.com/nodeset-org/nodeset-client-go v1.2.0/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
 github.com/nodeset-org/osha v0.3.1 h1:xHDjCswxGDazY/UsZ0QOpcu7gTVnEuUwXcKGVAz72lI=

--- a/go.sum
+++ b/go.sum
@@ -395,10 +395,10 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241007163607-e439ed3db62f h1:ogjzXS/x5bbPL5IGiIO7SS+kEgCs79m8p/Xl5qjqxkY=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241007163607-e439ed3db62f/go.mod h1:NS0CuHVVWW++j933beSACsJXFBdcH5TKRzBXIJmnacQ=
-github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963 h1:DhjPEnbtzPUEG+/INKjNHs7Q5JYA2aUURttcOD4WvGI=
-github.com/nodeset-org/nodeset-client-go v1.1.1-0.20241007162432-cba11fc62963/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241008194042-73dbca474c7e h1:5m+qFLazQKcx9+p0Wv5SaMZFt7ztZW5CkRRFgPTOyV8=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-b2.0.20241008194042-73dbca474c7e/go.mod h1:Vjdz7D7gAZr0NFMLgBfQN1/9/Nh+KiCFJWj+7tFcFTQ=
+github.com/nodeset-org/nodeset-client-go v1.2.0 h1:16GfFTkjMdgGiAdXWyLLMnLVHd+E6Rh+UYzS1i8/o+I=
+github.com/nodeset-org/nodeset-client-go v1.2.0/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
 github.com/nodeset-org/osha v0.3.1 h1:xHDjCswxGDazY/UsZ0QOpcu7gTVnEuUwXcKGVAz72lI=
 github.com/nodeset-org/osha v0.3.1/go.mod h1:47D6kYMuxYDTbul3w/YtE1LKA0hfzbXzCEC3M9oQlOU=
 github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20240731214747-81867bb8ff63 h1:8SYjAfLErqH0zRu4s+17oAmFE0MrAS3GcTaIIm3u1O0=
@@ -472,8 +472,8 @@ github.com/rocket-pool/batch-query v1.0.0 h1:5HejmT1n1fIdLIqUhTNwbkG2PGOPl3IVjCp
 github.com/rocket-pool/batch-query v1.0.0/go.mod h1:d1CmxShzk0fioJ4yX0eFGhz2an1odnW/LZ2cp3eDGIQ=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd h1:p9KuetSKB9nte9I/MkkiM3pwKFVQgqxxPTQ0y56Ff6s=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd/go.mod h1:UE9fof8P7iESVtLn1K9CTSkNRYVFHZHlf96RKbU33kA=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20241003024529-05c829d805c6 h1:QITxx3McsLw6Ov/6acjz58MI496Y05s4cn63zCXQskk=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20241003024529-05c829d805c6/go.mod h1:/H1wq3skacZi4zjgnKTtnm0wBLJH7H5r0CvLtWFs19Y=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20241008173134-e04f3c1b9051 h1:fUi7ZDDGsNK6lDmCaAwu2x2bRHSEj5KmMkRwA9p3yVU=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20241008173134-e04f3c1b9051/go.mod h1:/H1wq3skacZi4zjgnKTtnm0wBLJH7H5r0CvLtWFs19Y=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=

--- a/internal/tests/utils/harness.go
+++ b/internal/tests/utils/harness.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	cstesting "github.com/nodeset-org/hyperdrive-constellation/testing"
+	hdtesting "github.com/nodeset-org/hyperdrive-daemon/testing"
 	"github.com/nodeset-org/osha/keys"
 	"github.com/rocket-pool/node-manager-core/wallet"
 	"github.com/rocket-pool/rocketpool-go/v2/node"
@@ -144,6 +145,7 @@ func CreateStandardTestHarness(options *StandardTestHarnessOptions) (*StandardTe
 		csMgr.SuperNodeAccount.Address,
 	)
 	deployment.SetAdminPrivateKey(deployerKey)
+	nsDB.SetSecretEncryptionIdentity(hdtesting.EncryptionIdentity)
 
 	// Make the contract bindings
 	bindings, err := CreateBindings(sp)

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,5 +1,5 @@
 package shared
 
 const (
-	ConstellationVersion string = "1.0.0-dev"
+	ConstellationVersion string = "1.0.0-rc1"
 )

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,5 +1,5 @@
 package shared
 
 const (
-	ConstellationVersion string = "1.0.0-b2"
+	ConstellationVersion string = "1.0.0-dev"
 )


### PR DESCRIPTION
This encrypts signed exit messages explicitly and uploads the encrypted payload to nodeset.io, rather than relying exclusively on TLS encryption. Credit goes to @poupas for suggesting this feature.

Side-effect: also bumps the version to RC1, as this is the only expected change for it.