### PR TITLE
Fix submit exit log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,11 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-version v1.6.0
-	github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1
+	github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1.0.20241010055911-fb487fa8c4b3
 	github.com/nodeset-org/nodeset-client-go v1.2.0
 	github.com/nodeset-org/osha v0.3.1
 	github.com/rocket-pool/batch-query v1.0.0
-	github.com/rocket-pool/node-manager-core v0.5.2-0.20241008173134-e04f3c1b9051
+	github.com/rocket-pool/node-manager-core v0.5.2-0.20241009172604-e8458aa7509b
 	github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b
 	github.com/rocket-pool/smartnode/v2 v2.0.0-olddev.0.20240710181452-edcbd6208bdd
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1 h1:H7mfO7upKMvPmpl1wOLR8IU8EEcagnPdVl0BEV/TBLk=
-github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1/go.mod h1:Vjdz7D7gAZr0NFMLgBfQN1/9/Nh+KiCFJWj+7tFcFTQ=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1.0.20241010055911-fb487fa8c4b3 h1:Dq5hLJR9otA/us1c1f0bjYnQ9cv7NPEXQi6OIETrpDg=
+github.com/nodeset-org/hyperdrive-daemon v1.1.0-rc1.0.20241010055911-fb487fa8c4b3/go.mod h1:At4TLPU8oheMxqCr0mr4oaAR6CVsTCpKNWgZox9B4Ho=
 github.com/nodeset-org/nodeset-client-go v1.2.0 h1:16GfFTkjMdgGiAdXWyLLMnLVHd+E6Rh+UYzS1i8/o+I=
 github.com/nodeset-org/nodeset-client-go v1.2.0/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
 github.com/nodeset-org/osha v0.3.1 h1:xHDjCswxGDazY/UsZ0QOpcu7gTVnEuUwXcKGVAz72lI=
@@ -472,8 +472,8 @@ github.com/rocket-pool/batch-query v1.0.0 h1:5HejmT1n1fIdLIqUhTNwbkG2PGOPl3IVjCp
 github.com/rocket-pool/batch-query v1.0.0/go.mod h1:d1CmxShzk0fioJ4yX0eFGhz2an1odnW/LZ2cp3eDGIQ=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd h1:p9KuetSKB9nte9I/MkkiM3pwKFVQgqxxPTQ0y56Ff6s=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd/go.mod h1:UE9fof8P7iESVtLn1K9CTSkNRYVFHZHlf96RKbU33kA=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20241008173134-e04f3c1b9051 h1:fUi7ZDDGsNK6lDmCaAwu2x2bRHSEj5KmMkRwA9p3yVU=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20241008173134-e04f3c1b9051/go.mod h1:/H1wq3skacZi4zjgnKTtnm0wBLJH7H5r0CvLtWFs19Y=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20241009172604-e8458aa7509b h1:92Bkj4cNF42VQv9Q5/3gSmogzZ5PlWboCoiTSwqQLPA=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20241009172604-e8458aa7509b/go.mod h1:/H1wq3skacZi4zjgnKTtnm0wBLJH7H5r0CvLtWFs19Y=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,5 +1,5 @@
 package shared
 
 const (
-	ConstellationVersion string = "1.0.0-rc1"
+	ConstellationVersion string = "1.0.0-dev"
 )


### PR DESCRIPTION
This updates NMC and HD, and fixes an issue I noticed in testing RC1 where the `submit-exits` task would print a false warning in the logs if an existing validator didn't need a signed exit uploaded.