### PR TITLE
Add skip-check flags to `minipool create`

### DIFF
--- a/client/minipool.go
+++ b/client/minipool.go
@@ -41,9 +41,11 @@ func (r *MinipoolRequester) GetCloseDetails() (*types.ApiResponse[csapi.Minipool
 }
 
 // Deposit to Constellation to create a new minipool
-func (r *MinipoolRequester) Create(salt *big.Int) (*types.ApiResponse[csapi.MinipoolCreateData], error) {
+func (r *MinipoolRequester) Create(salt *big.Int, skipLiquidityCheck bool, skipBalanceCheck bool) (*types.ApiResponse[csapi.MinipoolCreateData], error) {
 	args := map[string]string{
-		"salt": salt.String(),
+		"salt":               salt.String(),
+		"skipLiquidityCheck": strconv.FormatBool(skipLiquidityCheck),
+		"skipBalanceCheck":   strconv.FormatBool(skipBalanceCheck),
 	}
 	return client.SendGetRequest[csapi.MinipoolCreateData](r, "create", "Create", args)
 }

--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/rocket-pool/rocketpool-go/v2 => github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20240731214747-81867bb8ff63
+replace github.com/rocket-pool/rocketpool-go/v2 => github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20241026065119-927a7f649ce0
 
 replace github.com/rocket-pool/smartnode/v2 => github.com/nodeset-org/rocketpool-smartnode/v2 v2.0.0-olddev.0.20241002073413-7c50008efc66
 

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/nodeset-org/nodeset-client-go v1.2.1 h1:2Nybz1IONZBCD+j4+MgRBIvA3dNW4
 github.com/nodeset-org/nodeset-client-go v1.2.1/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
 github.com/nodeset-org/osha v0.3.1 h1:xHDjCswxGDazY/UsZ0QOpcu7gTVnEuUwXcKGVAz72lI=
 github.com/nodeset-org/osha v0.3.1/go.mod h1:47D6kYMuxYDTbul3w/YtE1LKA0hfzbXzCEC3M9oQlOU=
-github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20240731214747-81867bb8ff63 h1:8SYjAfLErqH0zRu4s+17oAmFE0MrAS3GcTaIIm3u1O0=
-github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20240731214747-81867bb8ff63/go.mod h1:pcY43H/m5pjr7zacrsKVaXnXfKKi1UV08VDPUwxbJkc=
+github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20241026065119-927a7f649ce0 h1:7SBIV7eMKXCGGtiPTfL1iEabFR6+SpSCwsLMK8lczEo=
+github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20241026065119-927a7f649ce0/go.mod h1:pcY43H/m5pjr7zacrsKVaXnXfKKi1UV08VDPUwxbJkc=
 github.com/nodeset-org/rocketpool-smartnode/v2 v2.0.0-olddev.0.20241002073413-7c50008efc66 h1:buIjoSU+scq/fjq1OfvQiYzsoVFiPw/qoXtNO7+vu/Y=
 github.com/nodeset-org/rocketpool-smartnode/v2 v2.0.0-olddev.0.20241002073413-7c50008efc66/go.mod h1:LNR6m7IpsEBDBm8T6vVsWOiepx8Fzumpf2laHKOjbGU=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/internal/tests/qa/qa_test.go
+++ b/internal/tests/qa/qa_test.go
@@ -470,7 +470,7 @@ func Test5_ComplexNOConcurrency(t *testing.T) {
 	for i, node := range wave3Nodes {
 		cs := node.GetApiClient()
 		salt := wave3Salts[i][0]
-		depositResponse, err := cs.Minipool.Create(salt)
+		depositResponse, err := cs.Minipool.Create(salt, false, false)
 		require.NoError(t, err)
 		require.False(t, depositResponse.Data.CanCreate)
 		require.True(t, depositResponse.Data.InsufficientLiquidity)
@@ -1204,7 +1204,7 @@ func Test15_StakingTest(t *testing.T) {
 	for i, node := range wave3Nodes {
 		cs := node.GetApiClient()
 		salt := wave3Salts[i][0]
-		depositResponse, err := cs.Minipool.Create(salt)
+		depositResponse, err := cs.Minipool.Create(salt, false, false)
 		require.NoError(t, err)
 		require.False(t, depositResponse.Data.CanCreate)
 		require.True(t, depositResponse.Data.InsufficientLiquidity)

--- a/internal/tests/utils/utils.go
+++ b/internal/tests/utils/utils.go
@@ -237,7 +237,7 @@ func BuildAndVerifyCreateMinipoolTxBeforeTest(logger *slog.Logger, deployment *d
 	cs := csNode.GetApiClient()
 
 	// Make the minipool
-	depositResponse, err := cs.Minipool.Create(salt)
+	depositResponse, err := cs.Minipool.Create(salt, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +475,7 @@ func BuildAndVerifyCreateMinipoolTx(t *testing.T, deployment *db.ConstellationDe
 	cs := csNode.GetApiClient()
 
 	// Make the minipool
-	depositResponse, err := cs.Minipool.Create(salt)
+	depositResponse, err := cs.Minipool.Create(salt, false, false)
 	require.NoError(t, err)
 	require.True(t, depositResponse.Data.CanCreate)
 	if shouldSucceed {

--- a/shared/version.go
+++ b/shared/version.go
@@ -1,5 +1,5 @@
 package shared
 
 const (
-	ConstellationVersion string = "1.0.0"
+	ConstellationVersion string = "1.0.1-dev"
 )


### PR DESCRIPTION
This updates some dependencies and introduces some flags to `minipool create` that let the user bypass the node balance and CS liquidity checks. There have been requests to add these so people can create and sign TX's without submitting them, so they can be included in bundles or later when liquidity levels are sufficient.