### PR TITLE
Fixed manual exit uploads interfering with the task

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,11 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/gorilla/mux v1.8.1
 	github.com/hashicorp/go-version v1.6.0
-	github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241028171353-e4b6a5d23ef7
-	github.com/nodeset-org/nodeset-client-go v1.2.1
+	github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241029202513-b6c52afaf416
+	github.com/nodeset-org/nodeset-client-go v1.2.2
 	github.com/nodeset-org/osha v0.3.1
 	github.com/rocket-pool/batch-query v1.0.0
-	github.com/rocket-pool/node-manager-core v0.5.2-0.20241026054448-4827602a297b
+	github.com/rocket-pool/node-manager-core v0.5.2-0.20241029172412-6cb22253be3f
 	github.com/rocket-pool/rocketpool-go/v2 v2.0.0-b2.0.20240709170030-c27aeb5fb99b
 	github.com/rocket-pool/smartnode/v2 v2.0.0-olddev.0.20240710181452-edcbd6208bdd
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -395,10 +395,10 @@ github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOEL
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241028171353-e4b6a5d23ef7 h1:11jfimBTQWhIHAwce1PyOldq4yYxLR2fgDcmN7ztGRM=
-github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241028171353-e4b6a5d23ef7/go.mod h1:Sy7Kl0785VqraP+xwwFnYbSDhBlulJGWco1Kw75AXKQ=
-github.com/nodeset-org/nodeset-client-go v1.2.1 h1:2Nybz1IONZBCD+j4+MgRBIvA3dNW4+ek1+kFtB/D6MY=
-github.com/nodeset-org/nodeset-client-go v1.2.1/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
+github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241029202513-b6c52afaf416 h1:vHexhcv14NhIuKJHwAGnRKFkgGXfVSJ88wddOPMQ7AA=
+github.com/nodeset-org/hyperdrive-daemon v1.1.1-0.20241029202513-b6c52afaf416/go.mod h1:tzqdqfRR4Xcy4GtdSiEnfjOFj3+g4TvuZJpYljCQEBM=
+github.com/nodeset-org/nodeset-client-go v1.2.2 h1:mjJnH5uw/CF5TWdRxdU5+Cw/ERRLz4hl9VsRFVO0Wdo=
+github.com/nodeset-org/nodeset-client-go v1.2.2/go.mod h1:TATOnCsIvDjC7C+h1izgw0+t35N40Hr/CxhgaLK78e4=
 github.com/nodeset-org/osha v0.3.1 h1:xHDjCswxGDazY/UsZ0QOpcu7gTVnEuUwXcKGVAz72lI=
 github.com/nodeset-org/osha v0.3.1/go.mod h1:47D6kYMuxYDTbul3w/YtE1LKA0hfzbXzCEC3M9oQlOU=
 github.com/nodeset-org/rocketpool-go/v2 v2.0.0-b2.0.20241026065119-927a7f649ce0 h1:7SBIV7eMKXCGGtiPTfL1iEabFR6+SpSCwsLMK8lczEo=
@@ -472,8 +472,8 @@ github.com/rocket-pool/batch-query v1.0.0 h1:5HejmT1n1fIdLIqUhTNwbkG2PGOPl3IVjCp
 github.com/rocket-pool/batch-query v1.0.0/go.mod h1:d1CmxShzk0fioJ4yX0eFGhz2an1odnW/LZ2cp3eDGIQ=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd h1:p9KuetSKB9nte9I/MkkiM3pwKFVQgqxxPTQ0y56Ff6s=
 github.com/rocket-pool/go-merkletree v1.0.1-0.20220406020931-c262d9b976dd/go.mod h1:UE9fof8P7iESVtLn1K9CTSkNRYVFHZHlf96RKbU33kA=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20241026054448-4827602a297b h1:4uNcp/gCHWh4R2BeOCOZKwbckNK1t2voB2n5cd6pXyg=
-github.com/rocket-pool/node-manager-core v0.5.2-0.20241026054448-4827602a297b/go.mod h1:/FFOK81WO/FZO+Y/9LeBRkVE17VkyyerAb9oBh9fpag=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20241029172412-6cb22253be3f h1:yGcY5EBYh/8f5zqyoorI3XHS/oD9uyGdbIpSOHSKWI8=
+github.com/rocket-pool/node-manager-core v0.5.2-0.20241029172412-6cb22253be3f/go.mod h1:/FFOK81WO/FZO+Y/9LeBRkVE17VkyyerAb9oBh9fpag=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=

--- a/shared/config/templating.go
+++ b/shared/config/templating.go
@@ -64,13 +64,13 @@ func (cfg *ConstellationConfig) IsDoppelgangerEnabled() bool {
 }
 
 // Used by text/template to format validator.yml
-func (cfg *ConstellationConfig) Graffiti() (string, error) {
+func (cfg *ConstellationConfig) Graffiti() string {
 	prefix := cfg.hdCfg.GraffitiPrefix()
 	customGraffiti := cfg.VcCommon.Graffiti.Value
 	if customGraffiti == "" {
-		return prefix, nil
+		return prefix
 	}
-	return fmt.Sprintf("%s (%s)", prefix, customGraffiti), nil
+	return fmt.Sprintf("%s (%s)", prefix, customGraffiti)
 }
 
 func (cfg *ConstellationConfig) IsEnabled() bool {


### PR DESCRIPTION
According to https://github.com/nodeset-org/hyperdrive/issues/187, doing a manual signed exit upload interferes with the upload task by invalidating its cache. nodeset.io will report an error if a signed exit is already present for a pubkey, so instead of erroring out, it needs to update the cache and ignore the signed exit that already exists. This PR does exactly that.